### PR TITLE
Compatiblity with delve

### DIFF
--- a/lister.el
+++ b/lister.el
@@ -430,6 +430,10 @@ If NODE is nil, return the last visible node of the EWOC."
                                    #'ewoc-prev))
 
 ;;; * Public API
+(defun lister-get-ewoc (buf)
+  "Get ewoc object associated with BUF."
+  (with-current-buffer buf
+    lister-local-ewoc))
 
 (defmacro lister-with-boundaries (ewoc beg-var end-var &rest body)
   "In EWOC, do BODY binding BEG-VAR and END-VAR to list nodes.

--- a/lister.el
+++ b/lister.el
@@ -1304,6 +1304,16 @@ as elements) and must not undo the wrapping."
            (new-list     (lister--reorder-wrapped-list wrapped-list fn)))
       (lister--replace-items ewoc new-list beg end level))))
 
+(defun lister-reorder-sublist-at (ewoc pos pred)
+  "Reorder the sublist at POS in EWOC by PRED."
+    (lister-with-sublist-at ewoc pos beg end
+    (lister--reorder ewoc pred beg end)))
+
+(defun lister-reorder-sublist-below (ewoc pos pred)
+  "Reorder the sublist below POS in EWOC by PRED."
+  (lister-with-sublist-at ewoc pos beg end
+    (lister--reorder ewoc pred beg end)))
+
 (defun lister-reverse-list (ewoc &optional beg end)
   "Reverse the list in EWOC, preserving sublist associatios.
 Use BEG and END to specify the first and the last item of the


### PR DESCRIPTION
Implements a couple of utility functions for compatibility with delve. 

- accessor function for ewoc 
- support marking predicate
- support reorder-sublist